### PR TITLE
Removed "http:"

### DIFF
--- a/zen/zen.html
+++ b/zen/zen.html
@@ -54,7 +54,7 @@
   <link rel="apple-touch-icon" href="{PortraitURL-128}">
 
   <link  href="//sanographix.github.io/public/tumblr/zen/2.x/css/style.css" rel="stylesheet" type="text/css" media="screen" charset="utf-8"/>
-  <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro' rel='stylesheet' type='text/css'>
+  <link href="//fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
 
   <!-- OGP -->
   <meta property="og:title" content="{block:PostTitle}{PostTitle} - {/block:PostTitle}{Title}" />


### PR DESCRIPTION
「http:」が入っていると､「https:」になっているTumblrのプレビュー画面でGoogle Fontが読み込まれません｡本番のフォントと同じように表示させるため､「http:」を外させていただきました｡

どうぞよろしくお願いいたします!