### PR TITLE
各 Tumblr テーマの DOCTYPE 宣言を削除

### DIFF
--- a/apollo/apollo.html
+++ b/apollo/apollo.html
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-
 <!--
   Theme: Apollo
   by @sanographix

--- a/illustfolio/illustfolio.html
+++ b/illustfolio/illustfolio.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <!--
   Theme: Illustfolio 1.3.0
   by @sanographix

--- a/illustfolio2/illustfolio2.html
+++ b/illustfolio2/illustfolio2.html
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-
 <!--
   Theme: Illustfolio 2
   by @sanographix

--- a/tokusetsu/tokusetsu.html
+++ b/tokusetsu/tokusetsu.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <!--
   Theme: Tokusetsu
   by @sanographix

--- a/tokusetsu2/tokusetsu2.html
+++ b/tokusetsu2/tokusetsu2.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <!--
   Theme: Tokusetsu 2
   by @sanographix

--- a/zen/zen.html
+++ b/zen/zen.html
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-
 <!--
   Theme: Zen
   by @sanographix


### PR DESCRIPTION
テーマの HTML をそのままコピペしたら、Tumblr のソース上で DOCTYPE 宣言が重複してしまったので、テーマに記述されている DOCTYPE 宣言を削除します。  
DOCTYPE 宣言は Tumblr 側で自動で先頭につけてくれるようです。

<img width="564" alt="screen shot 2017-10-25 at 0 26 00" src="https://user-images.githubusercontent.com/10768439/31952883-a00f014a-b91c-11e7-9b30-5c5bd03adb3c.png">