### PR TITLE
ZEN, Apollo の投稿日付部分に time 要素を追加

### DIFF
--- a/apollo/apollo.html
+++ b/apollo/apollo.html
@@ -144,7 +144,7 @@
           <footer class="entry-meta-header" role="contentinfo">
             {block:Date}
               <span class="meta-elements date">
-                <a href="{Permalink}">{ShortMonth} {DayOfMonthWithZero}, {Year}</a>
+                <a href="{Permalink}"><time datetime="{Year}-{MonthNumberWithZero}-{DayOfMonthWithZero}">{ShortMonth} {DayOfMonthWithZero}, {Year}</time></a>
               </span>
             {/block:Date}
             {block:IfAuthor}

--- a/zen/zen.html
+++ b/zen/zen.html
@@ -199,8 +199,8 @@
         ">
           {block:Date}
           <div class="date">
-            {block:NewDayDate}<p><a href="{Permalink}">{Year}-{MonthNumberWithZero}-{DayOfMonthWithZero}</a></p>{/block:NewDayDate}
-            {block:SameDayDate}<p><a href="{Permalink}">{Year}-{MonthNumberWithZero}-{DayOfMonthWithZero}</a></p>{/block:SameDayDate}
+            {block:NewDayDate}<p><a href="{Permalink}"><time datetime="{Year}-{MonthNumberWithZero}-{DayOfMonthWithZero}">{Year}-{MonthNumberWithZero}-{DayOfMonthWithZero}</time></a></p>{/block:NewDayDate}
+            {block:SameDayDate}<p><a href="{Permalink}"><time datetime="{Year}-{MonthNumberWithZero}-{DayOfMonthWithZero}">{Year}-{MonthNumberWithZero}-{DayOfMonthWithZero}</time></a></p>{/block:SameDayDate}
           </div>
           {/block:Date}
 


### PR DESCRIPTION
ZEN, Apollo の投稿日が表示される部分に `YYYY-MM-DD` 形式で time 要素を追加することで、マシンリーダブルな状態にします（ほかのテーマについては保留しています🙇‍♀️）。

参考:
- <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time>
- <https://www.w3.org/TR/2011/WD-html5-20110525/text-level-semantics.html#the-time-element>